### PR TITLE
support tls server connections

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,6 +14,7 @@ import (
 var (
 	configHost         string
 	configPort         int
+	configTls          bool
 	configCheckUpdates bool
 )
 
@@ -34,6 +35,9 @@ You can view or update the configuration for the Ollama CLI.`,
 			if cmd.Flags().Changed("port") {
 				cfg.Port = configPort
 			}
+			if cmd.Flags().Changed("tls") {
+				cfg.Tls = configTls
+			}
 			if cmd.Flags().Changed("check-updates") {
 				cfg.CheckUpdates = configCheckUpdates
 			}
@@ -51,6 +55,7 @@ You can view or update the configuration for the Ollama CLI.`,
 		output.Default.HeaderPrintln("Current configuration:")
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Host"), output.Highlight(cfg.Host))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Port"), output.Highlight(strconv.Itoa(cfg.Port)))
+		fmt.Printf("  %s: %s\n", output.MakeHeader("Tls"), output.Highlight(strconv.FormatBool(cfg.Tls)))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("URL"), output.Highlight(cfg.GetServerURL()))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Chat Enabled"), output.Highlight(strconv.FormatBool(cfg.ChatEnabled)))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Check Updates"), output.Highlight(strconv.FormatBool(cfg.CheckUpdates)))
@@ -77,6 +82,13 @@ var configSetCmd = &cobra.Command{
 				return
 			}
 			cfg.Port = port
+		case "tls":
+			tls, err := strconv.ParseBool(value)
+			if err != nil {
+				output.Default.ErrorPrintln("Error: tls must be a boolean (true/false)")
+				return
+			}
+			cfg.Tls = tls
 		case "check-updates":
 			checkUpdates, err := strconv.ParseBool(value)
 			if err != nil {
@@ -114,6 +126,8 @@ var configGetCmd = &cobra.Command{
 			fmt.Println(output.Highlight(cfg.Host))
 		case "port":
 			fmt.Println(output.Highlight(strconv.Itoa(cfg.Port)))
+		case "tls":
+			fmt.Println(output.Highlight(strconv.FormatBool(cfg.Tls)))
 		case "url":
 			fmt.Println(output.Highlight(cfg.GetServerURL()))
 		case "chat_enabled":
@@ -204,5 +218,6 @@ func init() {
 	// Add flags for the config command
 	configCmd.Flags().StringVar(&configHost, "host", "", "Ollama server host")
 	configCmd.Flags().IntVar(&configPort, "port", 0, "Ollama server port")
+	configCmd.Flags().BoolVar(&configTls, "tls", false, "Use TLS for Ollama server connection")
 	configCmd.Flags().BoolVar(&configCheckUpdates, "check-updates", true, "Check for updates")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,10 @@ It allows you to manage models, run inferences, and more.`,
 			port, _ := cmd.Flags().GetInt("port")
 			cfg.Port = port
 		}
+		if cmd.Flags().Changed("tls") {
+			tls, _ := cmd.Flags().GetBool("tls")
+			cfg.Tls = tls
+		}
 
 		return nil
 	},
@@ -85,6 +89,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configName, "config-name", "c", "", "config name to use (e.g. 'pc' for $HOME/.ollama-cli/pc.yaml)")
 	rootCmd.PersistentFlags().StringP("host", "H", "", "Ollama server host (default is localhost)")
 	rootCmd.PersistentFlags().Int("port", 0, "Ollama server port (default is 11434)")
+	rootCmd.PersistentFlags().Bool("tls", false, "Use TLS for Ollama server connection")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable color output")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&noUpdates, "no-updates", false, "Disable update checks")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ var CurrentConfigName string
 type Config struct {
 	Host         string `mapstructure:"host"`
 	Port         int    `mapstructure:"port"`
+	Tls          bool   `mapstructure:"tls"`
 	ChatEnabled  bool   `mapstructure:"chat_enabled"`
 	CheckUpdates bool   `mapstructure:"check_updates"`
 }
@@ -24,6 +25,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Host:         "localhost",
 		Port:         11434,
+		Tls:          false,
 		ChatEnabled:  false, // Chat is disabled by default
 		CheckUpdates: true,  // Check for updates by default
 	}
@@ -31,7 +33,11 @@ func DefaultConfig() *Config {
 
 // GetServerURL returns the full URL to the Ollama server
 func (c *Config) GetServerURL() string {
-	return fmt.Sprintf("http://%s:%d", c.Host, c.Port)
+	protocol := "http"
+	if c.Tls {
+		protocol = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", protocol, c.Host, c.Port)
 }
 
 // LoadConfig loads the configuration from the config file
@@ -60,6 +66,7 @@ func LoadConfig(configName ...string) (*Config, error) {
 		viper.SetConfigFile(configFile)
 		viper.Set("host", defaultConfig.Host)
 		viper.Set("port", defaultConfig.Port)
+		viper.Set("tls", defaultConfig.Tls)
 		viper.Set("chat_enabled", defaultConfig.ChatEnabled)
 		viper.Set("check_updates", defaultConfig.CheckUpdates)
 		if err := viper.WriteConfig(); err != nil {
@@ -98,6 +105,7 @@ func SaveConfig(config *Config, configName ...string) error {
 	viper.SetConfigFile(configFile)
 	viper.Set("host", config.Host)
 	viper.Set("port", config.Port)
+	viper.Set("tls", config.Tls)
 	viper.Set("chat_enabled", config.ChatEnabled)
 	viper.Set("check_updates", config.CheckUpdates)
 


### PR DESCRIPTION
This commit adds a new configuration flag '--tls' that allows connecting to an ollama server behind a reverse proxy that requires a TLS connection.