### PR TITLE
Allowed user to specify Ollama server path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Flags:
   -H, --host string          Ollama server host (default is localhost)
       --no-color             Disable color output
       --no-updates           Disable update checks
+      --path string          Ollama server path (empty by default)
   -p, --port int             Ollama server port (default is 11434)
   -v, --verbose              verbose output
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -31,6 +31,10 @@ func completeModelNames(cmd *cobra.Command, args []string, toComplete string) ([
 		host, _ := cmd.Flags().GetString("host")
 		cfg.Host = host
 	}
+	if cmd.Flags().Changed("path") {
+		path, _ := cmd.Flags().GetString("path")
+		cfg.Path = path
+	}
 	if cmd.Flags().Changed("port") {
 		port, _ := cmd.Flags().GetInt("port")
 		cfg.Port = port

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	configHost         string
+	configPath         string
 	configPort         int
 	configTls          bool
 	configCheckUpdates bool
@@ -23,14 +24,17 @@ var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Configure the Ollama CLI",
 	Long: `Configure the Ollama CLI.
-	
+
 You can view or update the configuration for the Ollama CLI.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// If flags are provided, update the configuration
-		if cmd.Flags().Changed("host") || cmd.Flags().Changed("port") || cmd.Flags().Changed("check-updates") {
+		if cmd.Flags().Changed("host") || cmd.Flags().Changed("path") || cmd.Flags().Changed("port") || cmd.Flags().Changed("check-updates") {
 			// Update the configuration
 			if cmd.Flags().Changed("host") {
 				config.Current.Host = configHost
+			}
+			if cmd.Flags().Changed("path") {
+				config.Current.Path = configPath
 			}
 			if cmd.Flags().Changed("port") {
 				config.Current.Port = configPort
@@ -55,6 +59,7 @@ You can view or update the configuration for the Ollama CLI.`,
 		output.Default.HeaderPrintln("Current configuration:")
 		cfg := config.Current
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Host"), output.Highlight(cfg.Host))
+		fmt.Printf("  %s: %s\n", output.MakeHeader("Path"), output.Highlight(cfg.Path))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Port"), output.Highlight(strconv.Itoa(cfg.Port)))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("Tls"), output.Highlight(strconv.FormatBool(cfg.Tls)))
 		fmt.Printf("  %s: %s\n", output.MakeHeader("URL"), output.Highlight(cfg.GetServerURL()))
@@ -76,6 +81,8 @@ var configSetCmd = &cobra.Command{
 		switch key {
 		case "host":
 			config.Current.Host = value
+		case "path":
+			config.Current.Path = value
 		case "port":
 			port, err := strconv.Atoi(value)
 			if err != nil {
@@ -125,6 +132,8 @@ var configGetCmd = &cobra.Command{
 		switch key {
 		case "host":
 			fmt.Println(output.Highlight(config.Current.Host))
+		case "path":
+			fmt.Println(output.Highlight(config.Current.Path))
 		case "port":
 			fmt.Println(output.Highlight(strconv.Itoa(config.Current.Port)))
 		case "tls":
@@ -218,6 +227,7 @@ func init() {
 
 	// Add flags for the config command
 	configCmd.Flags().StringVar(&configHost, "host", "", "Ollama server host")
+	configCmd.Flags().StringVar(&configPath, "path", "", "Ollama server path")
 	configCmd.Flags().IntVar(&configPort, "port", 0, "Ollama server port")
 	configCmd.Flags().BoolVar(&configTls, "tls", false, "Use TLS for Ollama server connection")
 	configCmd.Flags().BoolVar(&configCheckUpdates, "check-updates", true, "Check for updates")

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -84,6 +84,7 @@ func TestConfigCommand(t *testing.T) {
 			wantErr: false,
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "Host") &&
+					strings.Contains(output, "Path") &&
 					strings.Contains(output, "Port") &&
 					strings.Contains(output, "URL")
 			},
@@ -95,6 +96,18 @@ func TestConfigCommand(t *testing.T) {
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "example.com") &&
 					strings.Contains(output, "Host") &&
+					strings.Contains(output, "Path") &&
+					strings.Contains(output, "Port")
+			},
+		},
+		{
+			name:    "Set path flag",
+			args:    []string{"--path", "/test-api"},
+			wantErr: false,
+			checkOutput: func(output string) bool {
+				return strings.Contains(output, "/test-api") &&
+					strings.Contains(output, "Host") &&
+					strings.Contains(output, "Path") &&
 					strings.Contains(output, "Port")
 			},
 		},
@@ -105,17 +118,20 @@ func TestConfigCommand(t *testing.T) {
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "8080") &&
 					strings.Contains(output, "Host") &&
+					strings.Contains(output, "Path") &&
 					strings.Contains(output, "Port")
 			},
 		},
 		{
-			name:    "Set both host and port flags",
-			args:    []string{"--host", "test.com", "--port", "9090"},
+			name:    "Set host and path and port flags",
+			args:    []string{"--host", "test.com", "--path", "/test-api", "--port", "9090"},
 			wantErr: false,
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "test.com") &&
+					strings.Contains(output, "/test-api") &&
 					strings.Contains(output, "9090") &&
 					strings.Contains(output, "Host") &&
+					strings.Contains(output, "Path") &&
 					strings.Contains(output, "Port")
 			},
 		},
@@ -193,6 +209,15 @@ func TestConfigSetCommand(t *testing.T) {
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "example.com") &&
 					strings.Contains(output, "host")
+			},
+		},
+		{
+			name:    "Set path",
+			args:    []string{"path", "/test-api"},
+			wantErr: false,
+			checkOutput: func(output string) bool {
+				return strings.Contains(output, "/test-api") &&
+					strings.Contains(output, "path")
 			},
 		},
 		{
@@ -276,6 +301,7 @@ func TestConfigGetCommand(t *testing.T) {
 	origCfg := config.Current
 	config.Current = &config.Config{
 		Host: "test.example.com",
+		Path: "/test-api",
 		Port: 5555,
 	}
 	defer func() {
@@ -309,6 +335,14 @@ func TestConfigGetCommand(t *testing.T) {
 			wantErr: false,
 			checkOutput: func(output string) bool {
 				return strings.Contains(output, "test.example.com")
+			},
+		},
+		{
+			name:    "Get path",
+			args:    []string{"path"},
+			wantErr: false,
+			checkOutput: func(output string) bool {
+				return strings.Contains(output, "/test-api")
 			},
 		},
 		{
@@ -405,15 +439,16 @@ func TestConfigListCommand(t *testing.T) {
 	testConfigs := []struct {
 		name string
 		host string
+		path string
 		port int
 	}{
-		{"default", "localhost", 11434},
-		{"test1", "test1.example.com", 1111},
-		{"test2", "test2.example.com", 2222},
+		{"default", "localhost", "", 11434},
+		{"test1", "test1.example.com", "/path1", 1111},
+		{"test2", "test2.example.com", "/path2", 2222},
 	}
 
 	for _, tc := range testConfigs {
-		cfg := &config.Config{Host: tc.host, Port: tc.port}
+		cfg := &config.Config{Host: tc.host, Path: tc.path, Port: tc.port}
 		if err := config.SaveConfig(cfg, tc.name); err != nil {
 			t.Fatalf("Failed to save test config %s: %v", tc.name, err)
 		}
@@ -484,6 +519,16 @@ func TestConfigCommandFlags(t *testing.T) {
 	} else {
 		if hostFlag.DefValue != "" {
 			t.Errorf("host flag default value = %q, want %q", hostFlag.DefValue, "")
+		}
+	}
+
+	// Check path flag
+	pathFlag := cmd.Flag("path")
+	if pathFlag == nil {
+		t.Error("path flag not found")
+	} else {
+		if pathFlag.DefValue != "" {
+			t.Errorf("path flag default value = %q, want %q", pathFlag.DefValue, "")
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,10 @@ It allows you to manage models, run inferences, and more.`,
 			host, _ := cmd.Flags().GetString("host")
 			loadedCfg.Host = host
 		}
+		if cmd.Flags().Changed("path") {
+			path, _ := cmd.Flags().GetString("path")
+			loadedCfg.Path = path
+		}
 		if cmd.Flags().Changed("port") {
 			port, _ := cmd.Flags().GetInt("port")
 			loadedCfg.Port = port
@@ -89,6 +93,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ollama-cli/config.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&configName, "config-name", "c", "", "config name to use (e.g. 'pc' for $HOME/.ollama-cli/pc.yaml)")
 	rootCmd.PersistentFlags().StringP("host", "H", "", "Ollama server host (default is localhost)")
+	rootCmd.PersistentFlags().String("path", "", "Ollama server path (empty by default)")
 	rootCmd.PersistentFlags().Int("port", 0, "Ollama server port (default is 11434)")
 	rootCmd.PersistentFlags().Bool("tls", false, "Use TLS for Ollama server connection")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable color output")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var Current *Config
 // Config holds the configuration for the Ollama CLI
 type Config struct {
 	Host         string            `mapstructure:"host"`
+	Path         string            `mapstructure:"path"`
 	Port         int               `mapstructure:"port"`
 	Tls          bool              `mapstructure:"tls"`
 	ChatEnabled  bool              `mapstructure:"chat_enabled"`
@@ -31,6 +32,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Host:         "localhost",
+		Path:         "",
 		Port:         11434,
 		Tls:          false,
 		ChatEnabled:  false, // Chat is disabled by default
@@ -45,7 +47,7 @@ func (c *Config) GetServerURL() string {
 	if c.Tls {
 		protocol = "https"
 	}
-	return fmt.Sprintf("%s://%s:%d", protocol, c.Host, c.Port)
+	return fmt.Sprintf("%s://%s:%d%s", protocol, c.Host, c.Port, c.Path)
 }
 
 // LoadConfig loads the configuration from the config file
@@ -73,6 +75,7 @@ func LoadConfig(configName ...string) (*Config, error) {
 		defaultConfig := DefaultConfig()
 		viper.SetConfigFile(configFile)
 		viper.Set("host", defaultConfig.Host)
+		viper.Set("path", defaultConfig.Path)
 		viper.Set("port", defaultConfig.Port)
 		viper.Set("tls", defaultConfig.Tls)
 		viper.Set("chat_enabled", defaultConfig.ChatEnabled)
@@ -113,6 +116,7 @@ func SaveConfig(config *Config, configName ...string) error {
 
 	viper.SetConfigFile(configFile)
 	viper.Set("host", config.Host)
+	viper.Set("path", config.Path)
 	viper.Set("port", config.Port)
 	viper.Set("tls", config.Tls)
 	viper.Set("chat_enabled", config.ChatEnabled)


### PR DESCRIPTION
This PR solves #34. It adds the `--path` CLI option and `path:` config option letting a user specify a root path to access the API on.

Here's an demo of the new variable. Notice how the curl command uses the `/ollama-api` path, and `ollama-cli` throws an error until the `--path /ollama-api` param is specified.
<img width="1512" height="693" alt="Screenshot 2025-08-14 at 8 04 12 PM" src="https://github.com/user-attachments/assets/053f31f4-58b2-45fa-b157-e38cf58f8f2c" />

And here's an demo of the corresponding config changes.
<img width="722" height="408" alt="Screenshot 2025-08-14 at 8 11 26 PM" src="https://github.com/user-attachments/assets/57d6dbe1-2f39-47ed-9120-8f46cc07fea9" />

Test cases all pass.