### PR TITLE
Minor typo: unnecessary “api” path in base-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Available Commands:
   version     Display the version of the CLI tool
 
 Flags:
-      --base-url string      Full Ollama server URL (e.g. https://example.com:11434/api)
+      --base-url string      Full Ollama server URL (e.g. https://example.com:11434/)
       --config string        config file (default is $HOME/.ollama-cli/config.yaml)
   -c, --config-name string   config name to use (e.g. 'pc' for $HOME/.ollama-cli/pc.yaml)
   -h, --help                 help for ollama-cli

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,7 +94,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "base-url", "", "Full Ollama server URL (e.g. https://example.com:11434/api)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "base-url", "", "Full Ollama server URL (e.g. https://example.com:11434/)")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ollama-cli/config.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&configName, "config-name", "c", "", "config name to use (e.g. 'pc' for $HOME/.ollama-cli/pc.yaml)")
 	rootCmd.PersistentFlags().StringP("host", "H", "", "Ollama server host (default is localhost)")


### PR DESCRIPTION
The documentation and the help in the root.go command contain an extra "/api" that is innacurate.

- README.md deleting api from example url
- cmd/root.go removing api from example url